### PR TITLE
modified so travis doesn't use heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
+before_install:
+  - sed '/django-heroku/d' requirements.txt > requirements-build.txt
 install:
-  - pip install -r requirements.txt
+  - pip install -r requirements-build.txt
 # build multiple branches
 branches:
   only:

--- a/teamtwo/teamtwo/settings.py
+++ b/teamtwo/teamtwo/settings.py
@@ -10,7 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
-import django_heroku
+# import django_heroku
 import os
 from pathlib import Path
 from dotenv import load_dotenv
@@ -144,4 +144,11 @@ EMAIL_PORT = 587
 
 # Activate Django-Heroku.
 # django_heroku.settings(locals())
-django_heroku.settings(locals(), test_runner=False)
+# django_heroku.settings(locals(), test_runner=False)
+# Try to import django-heroku depending on Travis or Heroku
+try:
+    # Configure Django App for Heroku.
+    import django_heroku
+    django_heroku.settings(locals())
+except ImportError:
+    found = False


### PR DESCRIPTION
Updated .travis.yml and settings.py based on the suggestions in this post:
https://stackoverflow.com/questions/50805897/django-unit-tests-failing-on-travis-ci-builds/50988533