### PR TITLE
Display a list of ratings in the restroom detail page.

### DIFF
--- a/teamtwo/naturescall/forms.py
+++ b/teamtwo/naturescall/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.forms import widgets
 from .models import Restroom, Rating
 
 
@@ -16,7 +17,7 @@ class AddRestroom(forms.ModelForm):
         widget=forms.TextInput(attrs={"size": 80, "readonly": True}),
     )
     yelp_id = forms.SlugField(
-        disabled=False, widget=forms.TextInput(attrs={"size": 80, "readonly": True})
+        disabled=False, widget=forms.HiddenInput()
     )
     description = forms.CharField(widget=forms.TextInput(attrs={"size": 80}))
 

--- a/teamtwo/naturescall/forms.py
+++ b/teamtwo/naturescall/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.forms import widgets
 from .models import Restroom, Rating
 
 

--- a/teamtwo/naturescall/templates/naturescall/restroom_detail.html
+++ b/teamtwo/naturescall/templates/naturescall/restroom_detail.html
@@ -49,12 +49,24 @@
         </h2>
         <h4 class="card-text"> Address: {{res.addr}}</h4>
         <h4 class="card-text">Rating: {{res.yelp_data.rating}} </h4>
-        <!--
-        <h4 class="card-text">Rating: To Be Determined </h4>
-        -->
         <h4 class="card-text">Description: {{res.desc}} </h4>
         <a href="{% url 'naturescall:rate_restroom' res.yelp_data.db_id %}" class="btn btn-primary">Rate Now!</a>
       </div>
+    </div>
+  </div>
+</div>
+<br>
+<div class="container">
+  <div class="card">
+    <div class="card-body">
+      <h2 class="card-title">Ratings</h2>
+      {% for rating in ratings %}
+        <h4>{{rating.user_id}}</h4>
+        Rating: {{rating.rating}}<br>
+        Headline: {{rating.headline}}<br>
+        Comment: {{rating.comment}}<br>
+        <br>
+      {% endfor %}
     </div>
   </div>
 </div>

--- a/teamtwo/naturescall/tests.py
+++ b/teamtwo/naturescall/tests.py
@@ -374,3 +374,39 @@ class ViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["data"]), 1)
         self.assertEqual(len(response.context["data1"]), 19)
+
+    def test_newly_created_restroom_with_no_rating(self):
+        '''
+        A newly created restroom should have no rating
+        '''
+        yelp_id = "E6h-sMLmF86cuituw5zYxw"
+        desc = "Testing newly created restroom"
+        new_restroom = create_restroom(yelp_id, desc)
+        self.assertEqual(len(Rating.objects.filter(restroom_id=new_restroom.pk)), 0)
+
+    def test_multiple_ratings_shown_in_restroom_detail(self):
+        '''
+        If there are multiple ratings created
+        '''
+        yelp_id = "E6h-sMLmF86cuituw5zYxw"
+        desc = "Testing newly created restroom"
+        new_restroom = create_restroom(yelp_id, desc)
+        user1 = User.objects.create_user("Simon1", "simon1@email.com")
+        user2 = User.objects.create_user("Simon2", "simon2@email.com")
+        self.client.force_login(user=user1)
+        Rating.objects.create(
+            restroom_id=new_restroom,
+            user_id=user1,
+            rating="1",
+            headline="headline1",
+            comment="comment1",
+        )
+        self.client.force_login(user=user2)
+        Rating.objects.create(
+            restroom_id=new_restroom,
+            user_id=user2,
+            rating="4",
+            headline="headline2",
+            comment="comment2",
+        )
+        self.assertEqual(len(Rating.objects.filter(restroom_id=new_restroom.pk)), 2)

--- a/teamtwo/naturescall/views.py
+++ b/teamtwo/naturescall/views.py
@@ -237,7 +237,8 @@ def restroom_detail(request, r_id):
     else:
         raise Http404("Restroom does not exist")
 
-    context = {"res": res}
+    ratings = Rating.objects.filter(restroom_id=r_id)
+    context = {"res": res, "ratings": ratings}
     return render(request, "naturescall/restroom_detail.html", context)
 
 


### PR DESCRIPTION
1. Modified forms.py to hide yelp_id from add_restroom page.
2. Display a list of ratings in the restroom_detail page.