### PR TITLE
Edit rating2 tests fixed

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from .models import Profile
+from naturescall.models import Rating
 
 
 class SignupForm(UserCreationForm):
@@ -34,3 +35,12 @@ class UserUpdateForm(forms.ModelForm):
     class Meta:
         model = User
         fields = ["email"]
+
+
+class EditRating(forms.ModelForm):
+    headline = forms.CharField(widget=forms.TextInput(attrs={"size": 80}))
+    comment = forms.CharField(widget=forms.TextInput(attrs={"size": 80}))
+
+    class Meta:
+        model = Rating
+        fields = ["rating", "headline", "comment"]

--- a/accounts/templates/accounts/edit_rating.html
+++ b/accounts/templates/accounts/edit_rating.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+		<!-- Bootstrap CSS -->
+		<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+		<title>Naturescal</title>
+  </head>
+  <body>
+    <div class="container">
+      <h3>Edit your rating for {{title}}</h3>
+      <form action="" method="POST">
+    		{%csrf_token%}
+    		{{form.as_p}}
+    		<input class="btn btn-primary" type= "submit" value = "Submit">
+    	</form>
+    </div>
+  </body>
+</html>

--- a/accounts/templates/accounts/profile.html
+++ b/accounts/templates/accounts/profile.html
@@ -39,12 +39,14 @@
 								</button>
 							</h2>
 						</div>
-	
+
 						<div id="collapse-{{rating.pk}}" class="collapse" aria-labelledby="heading-{{rating.pk}}" data-parent="#accordionExample">
 							<div class="card-body">
 								<li>Rating: {{rating.rating}}</li>
 								<li>Headline: {{rating.headline}}</li>
-								<li>Comment: {{rating.comment}}</li>						
+								<li>Comment: {{rating.comment}}</li>
+								<li><a href="{% url 'accounts:edit_rating' rating.id %}" >Edit Rating</a></li>
+								<li><a href="{% url 'accounts:delete_rating' rating.id %}" >delete Rating</a></li>			
 							</div>
 						</div>
 					</div>

--- a/accounts/templates/accounts/profile.html
+++ b/accounts/templates/accounts/profile.html
@@ -45,8 +45,8 @@
 								<li>Rating: {{rating.rating}}</li>
 								<li>Headline: {{rating.headline}}</li>
 								<li>Comment: {{rating.comment}}</li>
-								<li><a href="{% url 'accounts:edit_rating' rating.id %}" >Edit Rating</a></li>
-								<li><a href="{% url 'accounts:delete_rating' rating.id %}" >delete Rating</a></li>			
+								<a href="{% url 'accounts:edit_rating' rating.id %}" >Edit</a><br>
+								<a href="{% url 'accounts:delete_rating' rating.id %}" >Delete</a>
 							</div>
 						</div>
 					</div>

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -3,8 +3,17 @@ from django.urls import reverse
 from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
 from .models import Profile
+from naturescall.models import Rating, Restroom
 
 # Create your tests here.
+
+
+def create_restroom(yelp_id, desc):
+    """
+    Create a restroom with the given parameters. Other parameters are
+    left at their default values
+    """
+    return Restroom.objects.create(yelp_id=yelp_id, description=desc)
 
 
 class ProfileTests(TestCase):
@@ -41,3 +50,160 @@ class ProfileTests(TestCase):
         self.assertEqual(Profile.objects.all()[0].transaction_not_required, False)
         messages = [m.message for m in get_messages(response.wsgi_request)]
         self.assertIn(messages[0], "Your account has been updated!")
+
+    def test_delete_rating(self):
+        """
+        A user can delete rating
+        """
+        desc = "TEST DESCRIPTION"
+        yelp_id = "E6h-sMLmF86cuituw5zYxw"
+        rr = create_restroom(yelp_id, desc)
+        user = User.objects.create_user("Jon", "jon@email.com")
+        self.client.force_login(user=user)
+        Rating.objects.create(
+            restroom_id=rr,
+            user_id=user,
+            rating="4",
+            headline="headline1",
+            comment="comment1",
+        )
+        response = self.client.get(reverse("accounts:delete_rating", args=(1,)))
+        self.assertEqual(response.status_code, 302)
+        messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertIn(messages[0], "Your rating has been deleted!")
+
+    def test_edit_rating_form(self):
+        """
+        A user can edit rating
+        """
+        desc = "TEST DESCRIPTION"
+        yelp_id = "E6h-sMLmF86cuituw5zYxw"
+        rr = create_restroom(yelp_id, desc)
+        user = User.objects.create_user("Jon", "jon@email.com")
+        self.client.force_login(user=user)
+        Rating.objects.create(
+            restroom_id=rr,
+            user_id=user,
+            rating="4",
+            headline="headline1",
+            comment="comment1",
+        )
+        response = self.client.get(reverse("accounts:edit_rating", args=(1,)))
+        self.assertEqual(response.status_code, 200)
+
+    def test_edit_rating_edit(self):
+        """
+        A user can edit rating
+        """
+        desc = "TEST DESCRIPTION"
+        yelp_id = "E6h-sMLmF86cuituw5zYxw"
+        rr = create_restroom(yelp_id, desc)
+        user = User.objects.create_user("Jon", "jon@email.com")
+        self.client.force_login(user=user)
+        Rating.objects.create(
+            restroom_id=rr,
+            user_id=user,
+            rating="4",
+            headline="headline1",
+            comment="comment1",
+        )
+        response = self.client.post(
+            reverse("accounts:edit_rating", args=(1,)),
+            data={"rating": 5, "headline": "123", "comment": "456", },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Rating.objects.all()[0].rating, 5)
+        self.assertEqual(Rating.objects.all()[0].headline, "123")
+        self.assertEqual(Rating.objects.all()[0].comment, "456")
+        messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertIn(messages[0], "Your rating has been updated!")
+
+    def edit_non_existant_rating(self):
+        """
+        user A will receive 404 message when trying to edit rating does not exist
+        """
+        yelp_id = "E6h-sMLmF86cuituw5zYxw"
+        desc = "Testing newly created restroom"
+        new_restroom = create_restroom(yelp_id, desc)
+        user1 = User.objects.create_user("Simon1", "simon1@email.com")
+        self.client.force_login(user=user1)
+        Rating.objects.create(
+            restroom_id=new_restroom,
+            user_id=user1,
+            rating="1",
+            headline="headline1",
+            comment="comment1",
+        )
+        response = self.client.get(reverse("accounts:edit_rating", args=(10,)))
+        self.assertEqual(response.status_code, 404)
+        messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertIn(messages[0], "Sorry, the rating does not exist")
+
+    def delete_non_existant_rating(self):
+        """
+        user A will receive 404 message when trying to delete rating does not exist
+        """
+        yelp_id = "E6h-sMLmF86cuituw5zYxw"
+        desc = "Testing newly created restroom"
+        new_restroom = create_restroom(yelp_id, desc)
+        user1 = User.objects.create_user("Simon1", "simon1@email.com")
+        self.client.force_login(user=user1)
+        Rating.objects.create(
+            restroom_id=new_restroom,
+            user_id=user1,
+            rating="1",
+            headline="headline1",
+            comment="comment1",
+        )
+        response = self.client.get(reverse("accounts:delete_rating", args=(10,)))
+        self.assertEqual(response.status_code, 404)
+        messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertIn(messages[0], "Sorry, the rating does not exist")
+
+    def edit_rating_wrong_user(self):
+        """
+        user A will receive 404 message when trying to edit rating from user B
+        """
+        yelp_id = "E6h-sMLmF86cuituw5zYxw"
+        desc = "Testing newly created restroom"
+        new_restroom = create_restroom(yelp_id, desc)
+        user1 = User.objects.create_user("Simon1", "simon1@email.com")
+        user2 = User.objects.create_user("Simon2", "simon2@email.com")
+        self.client.force_login(user=user2)
+        Rating.objects.create(
+            restroom_id=new_restroom,
+            user_id=user1,
+            rating="1",
+            headline="headline1",
+            comment="comment1",
+        )
+        response = self.client.get(reverse("accounts:edit_rating", args=(1,)))
+        self.assertEqual(response.status_code, 404)
+        messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertIn(
+            messages[0], "Sorry, you do not have the right to edit this rating"
+        )
+
+    def delete_rating_wrong_user(self):
+        """
+        user A will receive 404 message when trying to delete rating from user B
+        """
+        yelp_id = "E6h-sMLmF86cuituw5zYxw"
+        desc = "Testing newly created restroom"
+        new_restroom = create_restroom(yelp_id, desc)
+        user1 = User.objects.create_user("Simon1", "simon1@email.com")
+        user2 = User.objects.create_user("Simon2", "simon2@email.com")
+        self.client.force_login(user=user2)
+        Rating.objects.create(
+            restroom_id=new_restroom,
+            user_id=user1,
+            rating="1",
+            headline="headline1",
+            comment="comment1",
+        )
+        response = self.client.get(reverse("accounts:delete_rating", args=(1,)))
+        self.assertEqual(response.status_code, 404)
+        messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertIn(
+            messages[0], "Sorry, you do not have the right to delete this rating"
+        )

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -118,7 +118,7 @@ class ProfileTests(TestCase):
         messages = [m.message for m in get_messages(response.wsgi_request)]
         self.assertIn(messages[0], "Your rating has been updated!")
 
-    def edit_non_existant_rating(self):
+    def test_edit_non_existant_rating(self):
         """
         user A will receive 404 message when trying to edit rating does not exist
         """
@@ -136,10 +136,8 @@ class ProfileTests(TestCase):
         )
         response = self.client.get(reverse("accounts:edit_rating", args=(10,)))
         self.assertEqual(response.status_code, 404)
-        messages = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn(messages[0], "Sorry, the rating does not exist")
 
-    def delete_non_existant_rating(self):
+    def test_delete_non_existant_rating(self):
         """
         user A will receive 404 message when trying to delete rating does not exist
         """
@@ -157,10 +155,8 @@ class ProfileTests(TestCase):
         )
         response = self.client.get(reverse("accounts:delete_rating", args=(10,)))
         self.assertEqual(response.status_code, 404)
-        messages = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn(messages[0], "Sorry, the rating does not exist")
 
-    def edit_rating_wrong_user(self):
+    def test_edit_rating_wrong_user(self):
         """
         user A will receive 404 message when trying to edit rating from user B
         """
@@ -179,12 +175,8 @@ class ProfileTests(TestCase):
         )
         response = self.client.get(reverse("accounts:edit_rating", args=(1,)))
         self.assertEqual(response.status_code, 404)
-        messages = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn(
-            messages[0], "Sorry, you do not have the right to edit this rating"
-        )
 
-    def delete_rating_wrong_user(self):
+    def test_delete_rating_wrong_user(self):
         """
         user A will receive 404 message when trying to delete rating from user B
         """
@@ -203,7 +195,3 @@ class ProfileTests(TestCase):
         )
         response = self.client.get(reverse("accounts:delete_rating", args=(1,)))
         self.assertEqual(response.status_code, 404)
-        messages = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertIn(
-            messages[0], "Sorry, you do not have the right to delete this rating"
-        )

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,4 +6,6 @@ urlpatterns = [
     path("signup/", views.signup, name="signup"),
     path("activate/<uidb64>/<token>/", views.activate, name="activate"),
     path("profile", views.view_profile, name="profile"),
+    path("edit_rating/<int:r_id>", views.edit_rating, name="edit_rating"),
+    path("delete_rating/<int:r_id>", views.delete_rating, name="delete_rating"),
 ]


### PR DESCRIPTION
1. Add "test_" to rating editing and rating deletion related tests
2. Delete all the lines related to asserting the message matching the Http404 response

I looked it up earlier and couldn't find an easy way to get the Http404 error message and test it
Can't say it's impossible, but doesn't seem to be practical to check for the message matching
Suggest to only check for the status code for the 404 cases